### PR TITLE
Converts profits to int256

### DIFF
--- a/packages/hardhat/contracts/ClosedFund.sol
+++ b/packages/hardhat/contracts/ClosedFund.sol
@@ -683,10 +683,10 @@ contract ClosedFund is BaseFund, ReentrancyGuard {
         uint perfFee = 0;
         if (!_isDeposit) {
           uint percentage = balanceOf(msg.sender).div(_fundTokenQuantity); // Divide by the % tokens being withdrawn
-          uint profits = contributors[msg.sender].totalDeposit.div(percentage).sub(_reserveAssetQuantity);
+          int256 profits = _reserveAssetQuantity.toInt256().sub(contributors[msg.sender].totalDeposit.toInt256().div(percentage.toInt256()));
           if (profits > 0) {
             perfFee = IBabController(controller)
-            .getProtocolPerformanceFee().preciseMul(profits);
+            .getProtocolPerformanceFee().preciseMul(profits.toUint256());
           }
         }
 


### PR DESCRIPTION
Safe cast the _reserveAssetQuantity and the contributor's totalDeposit to int256 before applying the subtraction. Additionally, define the profit variable as int256 too.