### PR TITLE
Adds window of time for redemptions. Sets ETH aside

### DIFF
--- a/contracts/CommunityIdeas.sol
+++ b/contracts/CommunityIdeas.sol
@@ -353,7 +353,7 @@ contract CommunityIdeas is ReentrancyGuard {
     idea.exitedAt = block.timestamp;
     totalStake = totalStake.sub(idea.absoluteTotalVotes);
     // Transfer rewards and update positions
-     _transferIdeaRewards(_ideaIndex, capitalReturned);
+    _transferIdeaRewards(_ideaIndex, capitalReturned);
   }
 
   /* ============ External Getter Functions ============ */
@@ -448,8 +448,10 @@ contract CommunityIdeas is ReentrancyGuard {
       }
       reserveAssetDelta.add(int256(-stakeToSlash));
     }
+    // Start a redemption window in the community with this capital
+    community.startRedemptionWindow(capitalReturned);
     // Updates reserve asset position in the community
-    uint256 _newTotal = community.getPositionBalance(reserveAsset).add(int256(reserveAssetDelta)).toUint256();
+    uint256 _newTotal = community.getPositionBalance(reserveAsset).add(reserveAssetDelta).toUint256();
     community.calculateAndEditPosition(reserveAsset, _newTotal, reserveAssetDelta, 0);
   }
 

--- a/contracts/interfaces/IRollingCommunity.sol
+++ b/contracts/interfaces/IRollingCommunity.sol
@@ -68,6 +68,9 @@ interface IRollingCommunity is IERC20, ICommunity {
         uint256 _communityTokenQuantity
     ) external view returns (bool);
 
+    function startRedemptionWindow(uint256 _amount) external;
+    function reenableEthForInvestments() external;
+
     // Investment ideas
     function addInvestmentIdea(
       uint256 _capitalRequested,
@@ -84,4 +87,5 @@ interface IRollingCommunity is IERC20, ICommunity {
     function executeTopInvestment() external;
     function finalizeInvestment(uint _ideaIndex) external;
     function getCurrentTopInvestmentIdea() external view returns (uint8);
+    function canWithdrawEthAmount(address _amount) external view returns (bool);
 }


### PR DESCRIPTION
- After an investment idea executes, converts the capital returned (after the fees of the participants) to ETH and leaves it aside for withdrawals.
- Once the redemption window finishes, converts the ETH back to WETH