### PR TITLE
[HIGH] Compounding profits issue (internal security audit)

### DIFF
--- a/contracts/gardens/Garden.sol
+++ b/contracts/gardens/Garden.sol
@@ -437,7 +437,7 @@ contract Garden is ERC20Upgradeable, ReentrancyGuard, IGarden {
         IWETH(WETH).withdraw(_amount.add(_rewards));
 
         // Mark strategy as finalized
-        absoluteReturns.add(_returns);
+        absoluteReturns = absoluteReturns.add(_returns);
         strategies = strategies.remove(_strategy);
         finalizedStrategies.push(_strategy);
         strategyMapping[_strategy] = false;

--- a/contracts/strategies/Strategy.sol
+++ b/contracts/strategies/Strategy.sol
@@ -818,7 +818,7 @@ contract Strategy is ReentrancyGuard, IStrategy, Initializable {
                 IBabController(controller).treasury(),
                 protocolProfits
             );
-            reserveAssetDelta.add(int256(-protocolProfits));
+            reserveAssetDelta = reserveAssetDelta.add(int256(-protocolProfits));
         } else {
             // Returns were negative
             // Burn strategist stake and add the amount to the garden
@@ -832,14 +832,14 @@ contract Strategy is ReentrancyGuard, IStrategy, Initializable {
             }
 
             garden.burnStrategistStake(strategist, burningAmount);
-            reserveAssetDelta.add(int256(burningAmount));
+            reserveAssetDelta = reserveAssetDelta.add(int256(burningAmount));
         }
         // Return the balance back to the garden
         IERC20(reserveAsset).safeTransferFrom(address(this), address(garden), capitalReturned.sub(protocolProfits));
         // Start a redemption window in the garden with the capital plus the profits for the lps
         (, , uint256 lpsProfitSharing) = IBabController(controller).getProfitSharing();
         garden.startWithdrawalWindow(
-            capitalReturned.sub(protocolProfits).sub(profits).add((profits).preciseMul(lpsProfitSharing)),
+            capitalReturned.sub(profits).add((profits).preciseMul(lpsProfitSharing)),
             profits.sub(profits.preciseMul(lpsProfitSharing)).sub(protocolProfits),
             reserveAssetDelta,
             address(this)

--- a/test/gardens/Strategy.test.js
+++ b/test/gardens/Strategy.test.js
@@ -33,12 +33,28 @@ describe('Strategy', function () {
   let wethToken;
   let daiToken;
   let daiWethPair;
+  let treasury;
   let aaveLendIntegration;
   let kyberTradeIntegration;
   let uniswapPoolIntegration;
   let balancerIntegration;
   let oneInchPoolIntegration;
   let yearnVaultIntegration;
+
+  async function createStrategies(strategies) {
+    const retVal = [];
+    for (let i = 0; i < strategies.length; i++) {
+      const strategy = await createStrategy(
+        'buy',
+        'vote',
+        [signer1, signer2, signer3],
+        kyberTradeIntegration.address,
+        strategies[i].garden,
+      );
+      retVal.push(strategy);
+    }
+    return retVal;
+  }
 
   beforeEach(async () => {
     ({
@@ -47,6 +63,7 @@ describe('Strategy', function () {
       signer1,
       garden1,
       garden2,
+      treasury,
       strategy11,
       strategy21,
       signer2,
@@ -508,6 +525,197 @@ describe('Strategy', function () {
       await finalizeStrategy(strategyContract);
 
       await expect(strategyContract.finalizeStrategy(42, 'http://', { gasPrice: 0 })).to.be.reverted;
+    });
+  });
+  describe('Profits and re-staking (compounding) calculations', async function () {
+    it('should correctly calculate profits (strategist and stewards) and re-staking values of 5 strategies', async function () {
+      const [long1, long2, long3, long4, long5] = await createStrategies([
+        { garden: garden1 },
+        { garden: garden1 },
+        { garden: garden2 },
+        { garden: garden2 },
+        { garden: garden2 },
+      ]);
+
+      await executeStrategy(long1, ONE_ETH);
+      await executeStrategy(long2, ONE_ETH);
+      await executeStrategy(long3, ONE_ETH);
+      await executeStrategy(long4, ONE_ETH);
+      await executeStrategy(long5, ONE_ETH);
+
+      increaseTime(ONE_DAY_IN_SECONDS * 30);
+
+      await injectFakeProfits(long1, ONE_ETH.mul(200));
+      await finalizeStrategy(long1);
+      const reserveAssetRewardsSetAsideLong1 = await garden1.reserveAssetRewardsSetAside();
+      expect(reserveAssetRewardsSetAsideLong1.toString()).to.equal('14263257018321332');
+      const reserveAssetPrincipalWindowLong1 = await garden1.reserveAssetPrincipalWindow();
+      expect(reserveAssetPrincipalWindowLong1.toString()).to.equal('1076070704097713768');
+
+      // Strategy long2 has not profits
+      await finalizeStrategy(long2);
+      const reserveAssetRewardsSetAsideLong2 = await garden1.reserveAssetRewardsSetAside();
+      expect(reserveAssetRewardsSetAsideLong2).to.be.equal(reserveAssetRewardsSetAsideLong1);
+      const reserveAssetPrincipalWindowLong2 = await garden1.reserveAssetPrincipalWindow();
+      expect(reserveAssetPrincipalWindowLong2.toString()).to.be.equal('2070292936797564506');
+
+      await injectFakeProfits(long3, ONE_ETH.mul(200));
+      await finalizeStrategy(long3);
+      const reserveAssetRewardsSetAsideLong3 = await garden2.reserveAssetRewardsSetAside();
+      expect(reserveAssetRewardsSetAsideLong3.toString()).to.equal('14059543132871058');
+      const reserveAssetPrincipalWindowLong3 = await garden2.reserveAssetPrincipalWindow();
+      expect(reserveAssetPrincipalWindowLong3.toString()).to.equal('1074984230041978971');
+
+      await injectFakeProfits(long4, ONE_ETH.mul(222));
+      await finalizeStrategy(long4);
+
+      const reserveAssetRewardsSetAsideLong4 = await garden2.reserveAssetRewardsSetAside();
+      expect(reserveAssetRewardsSetAsideLong4.toString()).to.equal('29739669895858083');
+      const reserveAssetPrincipalWindowLong4 = await garden2.reserveAssetPrincipalWindow();
+      expect(reserveAssetPrincipalWindowLong4.toString()).to.equal('2158611572777909767');
+
+      await injectFakeProfits(long5, ONE_ETH.mul(222));
+      await finalizeStrategy(long5);
+      const reserveAssetRewardsSetAsideLong5 = await garden2.reserveAssetRewardsSetAside();
+      expect(reserveAssetRewardsSetAsideLong5.toString()).to.equal('45396038945381162');
+      const reserveAssetPrincipalWindowLong5 = await garden2.reserveAssetPrincipalWindow();
+      expect(reserveAssetPrincipalWindowLong5.toString()).to.equal('3242112207708699515');
+    });
+    it('should correctly receive the performance fee (in WETH) by the treasury in profit strategies', async function () {
+      const [long1, long2, long3, long4, long5] = await createStrategies([
+        { garden: garden1 },
+        { garden: garden1 },
+        { garden: garden2 },
+        { garden: garden2 },
+        { garden: garden2 },
+      ]);
+
+      await executeStrategy(long1, ONE_ETH);
+      await executeStrategy(long2, ONE_ETH);
+      await executeStrategy(long3, ONE_ETH);
+      await executeStrategy(long4, ONE_ETH);
+      await executeStrategy(long5, ONE_ETH);
+
+      increaseTime(ONE_DAY_IN_SECONDS * 30);
+
+      const treasuryBalance0 = await wethToken.balanceOf(treasury.address);
+      expect(treasuryBalance0.toString()).to.be.equal('25000000000000000');
+
+      await injectFakeProfits(long1, ONE_ETH.mul(200));
+      await finalizeStrategy(long1);
+      const treasuryBalance1 = await wethToken.balanceOf(treasury.address);
+      expect(treasuryBalance1).to.be.closeTo(ethers.BigNumber.from('29754419006107100'), 100);
+
+      // Strategy long2 has not profits
+      await finalizeStrategy(long2);
+      const treasuryBalance2 = await wethToken.balanceOf(treasury.address);
+      expect(treasuryBalance2).to.be.closeTo(ethers.BigNumber.from('29754419006107100'), 100);
+
+      await injectFakeProfits(long3, ONE_ETH.mul(200));
+      await finalizeStrategy(long3);
+      const treasuryBalance3 = await wethToken.balanceOf(treasury.address);
+      expect(treasuryBalance3).to.be.closeTo(ethers.BigNumber.from('34440933383730700'), 100);
+
+      await injectFakeProfits(long4, ONE_ETH.mul(222));
+      await finalizeStrategy(long4);
+      const treasuryBalance4 = await wethToken.balanceOf(treasury.address);
+      expect(treasuryBalance4).to.be.closeTo(ethers.BigNumber.from('39667642304726400'), 100);
+
+      await injectFakeProfits(long5, ONE_ETH.mul(222));
+      await finalizeStrategy(long5);
+      const treasuryBalance5 = await wethToken.balanceOf(treasury.address);
+      expect(treasuryBalance5).to.be.closeTo(ethers.BigNumber.from('44886431987900800'), 100);
+    });
+
+    it('capital returned should equals startWithdrawalWindow param 1 + param 2 + protocol performance fee 5% (if any) in all strategies', async function () {
+      const [long1, long2, long3, long4, long5] = await createStrategies([
+        { garden: garden1 },
+        { garden: garden1 },
+        { garden: garden2 },
+        { garden: garden2 },
+        { garden: garden2 },
+      ]);
+
+      await executeStrategy(long1, ONE_ETH);
+      await executeStrategy(long2, ONE_ETH);
+      await executeStrategy(long3, ONE_ETH);
+      await executeStrategy(long4, ONE_ETH);
+      await executeStrategy(long5, ONE_ETH);
+
+      increaseTime(ONE_DAY_IN_SECONDS * 30);
+
+      const treasuryBalance0 = await wethToken.balanceOf(treasury.address);
+      expect(treasuryBalance0.toString()).to.be.equal('25000000000000000');
+
+      await injectFakeProfits(long1, ONE_ETH.mul(200));
+      await finalizeStrategy(long1);
+      const treasuryBalance1 = await wethToken.balanceOf(treasury.address);
+      const feeLong1 = treasuryBalance1 - treasuryBalance0;
+      const reserveAssetRewardsSetAsideLong1 = await garden1.reserveAssetRewardsSetAside();
+      const reserveAssetPrincipalWindowLong1 = await garden1.reserveAssetPrincipalWindow();
+      const capitalReturnedLong1 = await long1.capitalReturned();
+      const valueLong1 = reserveAssetRewardsSetAsideLong1.add(reserveAssetPrincipalWindowLong1).add(feeLong1);
+
+      expect(capitalReturnedLong1).to.be.closeTo(valueLong1, 10);
+
+      // Strategy long2 has not profits
+      await finalizeStrategy(long2);
+      const treasuryBalance2 = await wethToken.balanceOf(treasury.address);
+      const feeLong2 = treasuryBalance2 - treasuryBalance1;
+      const reserveAssetRewardsSetAsideLong2 = (await garden1.reserveAssetRewardsSetAside()).sub(
+        reserveAssetRewardsSetAsideLong1,
+      );
+      const reserveAssetPrincipalWindowLong2 = (await garden1.reserveAssetPrincipalWindow()).sub(
+        reserveAssetPrincipalWindowLong1,
+      );
+
+      const capitalReturnedLong2 = await long2.capitalReturned();
+      const valueLong2 = reserveAssetRewardsSetAsideLong2.add(reserveAssetPrincipalWindowLong2).add(feeLong2);
+
+      expect(capitalReturnedLong2).to.be.closeTo(valueLong2, 10);
+
+      await injectFakeProfits(long3, ONE_ETH.mul(200));
+      await finalizeStrategy(long3);
+      const treasuryBalance3 = await wethToken.balanceOf(treasury.address);
+      const feeLong3 = treasuryBalance3 - treasuryBalance2;
+      const reserveAssetRewardsSetAsideLong3 = await garden2.reserveAssetRewardsSetAside();
+      const reserveAssetPrincipalWindowLong3 = await garden2.reserveAssetPrincipalWindow();
+
+      const capitalReturnedLong3 = await long3.capitalReturned();
+      const valueLong3 = reserveAssetRewardsSetAsideLong3.add(reserveAssetPrincipalWindowLong3).add(feeLong3);
+
+      expect(capitalReturnedLong3).to.be.closeTo(valueLong3, 10);
+
+      await injectFakeProfits(long4, ONE_ETH.mul(222));
+      await finalizeStrategy(long4);
+      const treasuryBalance4 = await wethToken.balanceOf(treasury.address);
+      const feeLong4 = treasuryBalance4 - treasuryBalance3;
+      const reserveAssetRewardsSetAsideLong4 = (await garden2.reserveAssetRewardsSetAside()).sub(
+        reserveAssetRewardsSetAsideLong3,
+      );
+      const reserveAssetPrincipalWindowLong4 = (await garden2.reserveAssetPrincipalWindow()).sub(
+        reserveAssetPrincipalWindowLong3,
+      );
+      const capitalReturnedLong4 = await long4.capitalReturned();
+      const valueLong4 = ethers.BigNumber.from(reserveAssetRewardsSetAsideLong4)
+        .add(ethers.BigNumber.from(reserveAssetPrincipalWindowLong4))
+        .add(ethers.BigNumber.from(feeLong4));
+      expect(capitalReturnedLong4).to.be.closeTo(valueLong4, 10);
+
+      await injectFakeProfits(long5, ONE_ETH.mul(222));
+      await finalizeStrategy(long5);
+      const treasuryBalance5 = await wethToken.balanceOf(treasury.address);
+      const feeLong5 = treasuryBalance5 - treasuryBalance4;
+      const reserveAssetRewardsSetAsideLong5 = (await garden2.reserveAssetRewardsSetAside())
+        .sub(reserveAssetRewardsSetAsideLong4)
+        .sub(reserveAssetRewardsSetAsideLong3);
+      const reserveAssetPrincipalWindowLong5 = (await garden2.reserveAssetPrincipalWindow())
+        .sub(reserveAssetPrincipalWindowLong4)
+        .sub(reserveAssetPrincipalWindowLong3);
+      const capitalReturnedLong5 = await long5.capitalReturned();
+      const valueLong5 = reserveAssetRewardsSetAsideLong5.add(reserveAssetPrincipalWindowLong5).add(feeLong5);
+
+      expect(capitalReturnedLong5).to.be.closeTo(valueLong5, 10);
     });
   });
 });


### PR DESCRIPTION
This PR fixes the following issues from the internal security audit:

1. // R [ISSUE][HIGH] First param seems to substract in a wrong way 2xprotocolProfits as they are included in profits.
(Refs. Strategy.sol line 859)
2. // R [ISSUE][HIGH] This statement is not adding or reducing protocolProfits from reserveAsset Delta
3.  // R [ISSUE][MEDIUM] absoluteReturns is not being updated unless we do absoluteReturns = absoluteReturns.add(_returns). As it is a param not used for anything else yet, we mark it as medium but it might produce an impact on the brand if users see absoluteReturns= 0 along the time.

HIGH issues were impacting the redistribution and re-staking of profits like follows:
(BEFORE FIX)
<img width="1230" alt="Captura de pantalla 2021-05-12 a las 18 37 03" src="https://user-images.githubusercontent.com/29550529/118012229-1e7a8180-b351-11eb-9d5e-2f5eda8a0518.png">

(AFTER FIX)

<img width="1229" alt="Captura de pantalla 2021-05-12 a las 18 34 06" src="https://user-images.githubusercontent.com/29550529/118011899-cd6a8d80-b350-11eb-8c04-df228c2d0e0f.png">

The Medium issue was not updating absoluteReturns but now it is being updated correctly:

<img width="750" alt="Captura de pantalla 2021-05-12 a las 18 35 07" src="https://user-images.githubusercontent.com/29550529/118012047-f1c66a00-b350-11eb-9104-c451a30b2f12.png">

All calculations here:
https://docs.google.com/spreadsheets/d/1oK-nMsokOlsdyyIcP0PdMIzLqkeLhjm3vILdmAwnfwg/edit#gid=622332182
