### PR TITLE
[HIGH] reduced to [LOW] startWithdrawalWindow fix by Internal Security Audit

### DIFF
--- a/contracts/gardens/Garden.sol
+++ b/contracts/gardens/Garden.sol
@@ -419,9 +419,8 @@ contract Garden is ERC20Upgradeable, ReentrancyGuard, IGarden {
         address _strategy
     ) external override {
         _require(
-            (strategyMapping[msg.sender] && address(IStrategy(msg.sender).garden()) == address(this)) ||
-                msg.sender == controller,
-            Errors.ONLY_STRATEGY_OR_CONTROLLER
+            (strategyMapping[msg.sender] && address(IStrategy(msg.sender).garden()) == address(this)),
+            Errors.ONLY_STRATEGY
         );
         // Updates reserve asset
         principal = principal.toInt256().add(_returns).toUint256();

--- a/test/gardens/Garden.test.js
+++ b/test/gardens/Garden.test.js
@@ -383,6 +383,30 @@ describe('Garden', function () {
       const afterBalance = await garden1.balanceOf(signer2.address);
       await expect(afterBalance).to.be.equal(beforeBalance.mul(lockedBalance).div(beforeBalance));
     });
+    it('should fail if startWithdrawalWindow is called more than once or from a non-strategy address', async function () {
+      const strategyContract = await createStrategy(
+        'buy',
+        'vote',
+        [signer1, signer2, signer3],
+        kyberTradeIntegration.address,
+        garden1,
+      );
+      // It is executed
+      await executeStrategy(strategyContract, ethers.utils.parseEther('1'), 42);
+
+      await injectFakeProfits(strategyContract, ethers.utils.parseEther('200')); // We inject positive profits
+      await finalizeStrategy(strategyContract, 0);
+      await expect(finalizeStrategy(strategyContract, 0)).to.be.revertedWith('revert BAB#050');
+
+      await expect(
+        garden1.startWithdrawalWindow(
+          ethers.BigNumber.from('1076070704097713768'),
+          ethers.BigNumber.from('14263257018321332'),
+          ethers.BigNumber.from('90333961116035100'),
+          '0xd41b236f19726aba094b8b9d130620bfef535fd0',
+        ),
+      ).to.be.revertedWith('revert BAB#020');
+    });
   });
   describe('Garden Balances', async function () {
     it('Garden WETH balance cannot be above deposit just after creation', async function () {


### PR DESCRIPTION
This PR fix a supposed [HIGH] issue from the Internal Security Audit that after creating the exploit (as seen in figure) it worked but the ArrayUtils stopped the malicious tx. Even the msg.sender should be an upgraded controller so it is likely not going to happen anytime. Anyway it must be called from official strategies and not from other origins (e.g. neither controller).



[PROBLEM]
1. // R [ISSUE][HIGH] If we call it more than once (e.g. 1st from a strategy and 2nd or even more by controller) we will create a mess duplicating reserveAssetRewards and withdrawaling twice.
(Refs. Garden.sol lines 420)
[EXPLOIT]
The exploit worked (adding more returns using the same and only one strategy by repeated calls) calling from 2 different places but it didnt work 100% as ArrayUtils didn't allow finally a new removal of the strategy which stucked the exploit (however there could be other potential ways to do it).
I decided to downsize from HIGH to LOW (or even INFORMATIVE) due to it was not 100% finally exploitable and even the caller must be a future version of the controller which is likely not to happen anytime.
<img width="950" alt="Captura de pantalla 2021-05-14 a las 18 41 20" src="https://user-images.githubusercontent.com/29550529/118304234-b78ed100-b4e6-11eb-9ca6-c98303c63e05.png">

[SOLUTION]
<img width="793" alt="Captura de pantalla 2021-05-14 a las 18 54 10" src="https://user-images.githubusercontent.com/29550529/118305360-21f44100-b4e8-11eb-9b8e-97c98ec83294.png">

