### PR TITLE
[HIGH] Enabling the controller to allow future public garden creations avoiding 1:1 IshtarGate delivery to any garden creator

### DIFF
--- a/contracts/BabController.sol
+++ b/contracts/BabController.sol
@@ -144,6 +144,9 @@ contract BabController is OwnableUpgradeable, IBabController {
     // Maximum number of contributors per garden
     uint256 public override maxContributorsPerGarden;
 
+    // Enable garden creations to be fully open to the public (no need of Ishtar gate anymore)
+    bool public override gardenCreationIsOpen;
+
     /* ============ Constructor ============ */
 
     /**
@@ -172,6 +175,7 @@ contract BabController is OwnableUpgradeable, IBabController {
 
         gardenCreatorBonus = 15e16;
         maxContributorsPerGarden = 100;
+        gardenCreationIsOpen = false;
     }
 
     /* ============ External Functions ============ */
@@ -197,7 +201,10 @@ contract BabController is OwnableUpgradeable, IBabController {
     ) external payable override returns (address) {
         require(defaultTradeIntegration != address(0), 'Need a default trade integration');
         require(enabledOperations.length > 0, 'Need operations enabled');
-        require(IIshtarGate(ishtarGate).canCreate(msg.sender), 'User does not have creation permissions');
+        require(
+            IIshtarGate(ishtarGate).canCreate(msg.sender) || gardenCreationIsOpen,
+            'User does not have creation permissions'
+        );
         address newGarden =
             IGardenFactory(gardenFactory).createGarden{value: msg.value}(
                 _reserveAsset,
@@ -253,6 +260,15 @@ contract BabController is OwnableUpgradeable, IBabController {
         IGarden garden = IGarden(_garden);
         require(!garden.active(), 'The garden needs to be disabled.');
         garden.setActive(true);
+    }
+
+    /**
+     * PRIVILEGED GOVERNANCE FUNCTION. Allows governance to enable public creation of gardens
+     *
+     */
+    function openPublicGardenCreation() external override onlyOwner {
+        require(!gardenCreationIsOpen, 'Garden creation is already open to the public');
+        gardenCreationIsOpen = true;
     }
 
     /**

--- a/contracts/interfaces/IBabController.sol
+++ b/contracts/interfaces/IBabController.sol
@@ -81,6 +81,10 @@ interface IBabController {
 
     function maxContributorsPerGarden() external view returns (uint256);
 
+    function gardenCreationIsOpen() external view returns (bool);
+
+    function openPublicGardenCreation() external;
+
     function setMaxContributorsPerGarden(uint256 _newMax) external;
 
     function editLiquidityMinimum(uint256 _minRiskyPairLiquidityEth) external;

--- a/contracts/mocks/BabControllerV2Mock.sol
+++ b/contracts/mocks/BabControllerV2Mock.sol
@@ -114,6 +114,9 @@ contract BabControllerV2Mock is OwnableUpgradeable {
     // Maximum number of contributors per garden
     uint256 public maxContributorsPerGarden;
 
+    // Enable garden creations to be fully open to the public (no need of Ishtar gate anymore)
+    bool public gardenCreationIsOpen;
+
     bool public newVar;
 
     /* ============ Constructor ============ */
@@ -142,6 +145,8 @@ contract BabControllerV2Mock is OwnableUpgradeable {
         lpsBABLPercentage = 75e16;
 
         gardenCreatorBonus = 15e16;
+        maxContributorsPerGarden = 100;
+        gardenCreationIsOpen = false;
     }
 
     /* ============ External Functions ============ */

--- a/test/gardens/Garden.test.js
+++ b/test/gardens/Garden.test.js
@@ -79,7 +79,25 @@ describe('Garden', function () {
       expect(await garden1.maxStrategyDuration()).to.equal(ONE_DAY_IN_SECONDS * 365);
     });
   });
-
+  describe('Garden creation open to public', async function () {
+    it('should allow the creation of a garden to a non-Ishtar gate user once garden creation is open to the public', async function () {
+      await expect(
+        babController
+          .connect(signer2)
+          .createGarden(addresses.tokens.WETH, 'TEST Ishtar', 'AAA', 'http:', 0, GARDEN_PARAMS, {
+            value: ethers.utils.parseEther('0.1'),
+          }),
+      ).to.be.revertedWith('revert User does not have creation permissions');
+      await babController.connect(owner).openPublicGardenCreation();
+      await expect(
+        babController
+          .connect(signer2)
+          .createGarden(addresses.tokens.WETH, 'TEST Ishtar', 'AAA', 'http:', 0, GARDEN_PARAMS, {
+            value: ethers.utils.parseEther('0.1'),
+          }),
+      ).not.to.be.reverted;
+    });
+  });
   describe('payKeeper', async function () {
     it('anyone can NOT invoke payKeeper', async function () {
       await expect(garden1.connect(signer1).payKeeper(keeper.address, ONE_ETH)).to.be.revertedWith('revert BAB#020');


### PR DESCRIPTION
This PR fix a future situation in which, after a decentralize governance decision to open garden creation to anyone to avoid manual 1:1 IshtarGates to be provided, we might not able to do so by a require in createGarden. 

By default it is disabled but now there is a possibility to open it once the governance decides and execute (set) it.

It fixes this [HIGH] from the Internal Security Audit:

1. // R [ISSUE][HIGH] We need to check what access process will have in the future in case Ishtar Gate vs. automation (open publicly to anyone) vs. other contributor checks (reputation, etc.). By using this require, we might need to continue minting any IshtarGate to any new user that maybe is not the best case for the future automated way.
(Refs. BabController.sol line 197)

[PROBLEM] (in the future we might have to provide continuous 1:1 support/access to each new user with gardener profile)
<img width="943" alt="Captura de pantalla 2021-05-14 a las 21 29 43" src="https://user-images.githubusercontent.com/29550529/118319794-8f5d9d00-b4fb-11eb-88ee-4574ea9bb199.png">

[SOLUTION]
Decentralized governance might decide to open public garden creation.
<img width="968" alt="Captura de pantalla 2021-05-14 a las 21 29 56" src="https://user-images.githubusercontent.com/29550529/118319925-bae08780-b4fb-11eb-9839-28d1d76cf4cd.png">


