### PR TITLE
Revert if nothing to claim

### DIFF
--- a/contracts/gardens/Garden.sol
+++ b/contracts/gardens/Garden.sol
@@ -17,7 +17,7 @@
 
 pragma solidity 0.7.6;
 
-//
+import 'hardhat/console.sol';
 import {Address} from '@openzeppelin/contracts/utils/Address.sol';
 import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import {SafeERC20} from '@openzeppelin/contracts/token/ERC20/SafeERC20.sol';
@@ -367,6 +367,7 @@ contract Garden is ERC20Upgradeable, ReentrancyGuard, IGarden {
         IRewardsDistributor rewardsDistributor = IRewardsDistributor(IBabController(controller).rewardsDistributor());
         (uint256 reserveRewards, uint256 bablRewards) =
             rewardsDistributor.getRewards(address(this), msg.sender, _finalizedStrategies);
+        _require(reserveRewards > 0 || bablRewards > 0, Errors.NO_REWARDS_TO_CLAIM);
 
         if (reserveRewards > 0 && address(this).balance >= reserveRewards) {
             contributor.claimedRewards = contributor.claimedRewards.add(reserveRewards); // Rewards claimed properly

--- a/contracts/lib/BabylonErrors.sol
+++ b/contracts/lib/BabylonErrors.sol
@@ -250,4 +250,6 @@ library Errors {
     uint256 internal constant CONTRIBUTOR_POWER_OVERFLOW = 80;
     // Contributor power window out of bounds
     uint256 internal constant CONTRIBUTOR_POWER_CHECK_DEPOSITS = 81;
+    // Contributor power window out of bounds
+    uint256 internal constant NO_REWARDS_TO_CLAIM = 82;
 }

--- a/test/token/RewardsDistributor.test.js
+++ b/test/token/RewardsDistributor.test.js
@@ -752,7 +752,9 @@ describe('BABL Rewards Distributor', function () {
       const contributor = await garden1.getContributor(signer1.address);
 
       // Try again to claims the same tokens but no more tokens are delivered
-      await garden1.connect(signer1).claimReturns([long1.address, long2.address]);
+      await expect(garden1.connect(signer1).claimReturns([long1.address, long2.address])).to.be.revertedWith(
+        'revert BAB#082',
+      );
       const contributor2 = await garden1.getContributor(signer1.address);
 
       await expect(contributor2[4].toString()).to.equal(contributor[4]);
@@ -761,8 +763,10 @@ describe('BABL Rewards Distributor', function () {
       await garden1.connect(signer2).claimReturns([long1.address, long2.address]);
       const contributor3 = await garden1.getContributor(signer2.address);
 
-      // Try again to claims the same tokens but no more tokens are delivered
-      await garden1.connect(signer2).claimReturns([long1.address, long2.address]);
+      // Try again to claims the same tokens but as there are no more tokens or rewards, it reverts
+      await expect(garden1.connect(signer2).claimReturns([long1.address, long2.address])).to.be.revertedWith(
+        'revert BAB#082',
+      );
       const contributor4 = await garden1.getContributor(signer2.address);
 
       await expect(contributor4[4].toString()).to.equal(contributor3[4]);


### PR DESCRIPTION
This PR will revert any claim that has nothing to claim (0 based on profit and 0 babl rewards) e.g. just after claiming. Let's see if this solves the behavior of dApp and avoid tx costs of users that try to claim nothing by mistake.