### PR TITLE
[HIGH-MEDIUM] Security fixes for delegationBySig

### DIFF
--- a/contracts/interfaces/IVoteToken.sol
+++ b/contracts/interfaces/IVoteToken.sol
@@ -28,7 +28,8 @@ interface IVoteToken {
         uint256 expiry,
         uint8 v,
         bytes32 r,
-        bytes32 s
+        bytes32 s,
+        bool prefix
     ) external;
 
     function getCurrentVotes(address account) external view returns (uint96);

--- a/contracts/token/VoteToken.sol
+++ b/contracts/token/VoteToken.sol
@@ -113,14 +113,22 @@ abstract contract VoteToken is Context, ERC20, Ownable, IVoteToken, ReentrancyGu
         uint256 expiry,
         uint8 v,
         bytes32 r,
-        bytes32 s
+        bytes32 s,
+        bool prefix
     ) external override {
+        address signatory;
         bytes32 domainSeparator =
             keccak256(abi.encode(DOMAIN_TYPEHASH, keccak256(bytes(name())), getChainId(), address(this)));
         bytes32 structHash = keccak256(abi.encode(DELEGATION_TYPEHASH, delegatee, nonce, expiry));
         bytes32 digest = keccak256(abi.encodePacked('\x19\x01', domainSeparator, structHash));
-        bytes32 digestHash = keccak256(abi.encodePacked('\x19Ethereum Signed Message:\n32', digest));
-        address signatory = ecrecover(digestHash, v, r, s);
+        if (prefix) {
+            bytes32 digestHash = keccak256(abi.encodePacked('\x19Ethereum Signed Message:\n32', digest));
+            signatory = ecrecover(digestHash, v, r, s);
+        } else {
+            signatory = ecrecover(digest, v, r, s);
+        }
+
+        require(balanceOf(signatory) > 0, 'VoteToken::delegateBySig: invalid delegator');
         require(signatory != address(0), 'VoteToken::delegateBySig: invalid signature');
         require(nonce == nonces[signatory], 'VoteToken::delegateBySig: invalid nonce');
         nonces[signatory]++;

--- a/test/token/VoteToken.test.js
+++ b/test/token/VoteToken.test.js
@@ -305,13 +305,27 @@ describe('VoteToken contract', function () {
       // second hash : 0xd7ead66ff6bda9784088e2deae972d920c55438e8a76149605393615ba546a29
       // third HASH: 0xab9f914973c2fc969ad6333b24425b6ad18a2e2196efc62d317ba823c1f7fe57
       // Digest = 0x297270268e4d1336f372fd9e5bedb193732205a6ba2be6ef06ae9edaeb4ece59
-      // TEST: 0xda1f5b19c6b1ffaeacc46f0c13692a10652a0caae172644e116160baf62480da60894b5c5a2b303d571d59726c883dff9fe419c3fb0defd9a3f061c5438072321c
       // ethSignedMessageHash (digestHash): 0xbebc4bc5916106fa2c548dc168127011ac043e8d41c889ae8f3f1104a6c85fbb
-
+      // METAMASK:
       // Signed message by Metamask = 0x4e302ab97d84f720d480d2fce8723158863f30c8557d14989d332966a41c1a5f7e2d62adc8c00d1c84f80fb75b2fcd38a934fad69c3091a5406d67b8c42db57a1b
       // Then splitting the signed message: Metamask
       // bytes32: r 0x4e302ab97d84f720d480d2fce8723158863f30c8557d14989d332966a41c1a5f
       // bytes32: s 0x7e2d62adc8c00d1c84f80fb75b2fcd38a934fad69c3091a5406d67b8c42db57a
+      // uint8: v 27
+      // LEDGER + METAMASK:
+      // LEDGER signed: 0x3e9140970233a167713ba23429c8ecc48272a60dd6e422cf6f1cead2bbee87af27ca269d6b4e98d3220f62d9f5b99caf75003e7b88d66ab77000a48537fd9b0901
+      // LEDGER signer: 0x232775eAD28F0C0c750A097bA77302E7d84efd3B
+      // LEDGER message hash: 764B2DA7FCBD5AD5F4EF2F1E5AAE23944EC984FD9AAEE7338237255EE96758D7
+      // LEDGER message hash website: 47CCC7A49206F6F21AEEC9928F4AD5F7513304B08180BE46BBD46B65941D0F8F
+      // LEDGER signed split:
+      // bytes32: r 0x3e9140970233a167713ba23429c8ecc48272a60dd6e422cf6f1cead2bbee87af
+      // bytes32: s 0x27ca269d6b4e98d3220f62d9f5b99caf75003e7b88d66ab77000a48537fd9b09
+      // uint8: v 1
+      // TREZOR:
+      // Signer: 0x4632F4120DC68F225e7d24d973Ee57478389e9Fd
+      // Signed message: dbf6a54764d0aa63a21c5ca49aed69195c3531dde0755490817db0764e1a76d44e32366a19416b58cedbb014c4cc67c76294e51f03443f89ae958f77631915121b
+      // bytes32: r 0xdbf6a54764d0aa63a21c5ca49aed69195c3531dde0755490817db0764e1a76d4
+      // bytes32: s 0x4e32366a19416b58cedbb014c4cc67c76294e51f03443f89ae958f7763191512
       // uint8: v 27
       // Enable BABL token transfers
       await bablToken.connect(owner).enableTokensTransfers();
@@ -321,10 +335,19 @@ describe('VoteToken contract', function () {
       const delegatee = '0x232775eAD28F0C0c750A097bA77302E7d84efd3B';
       const nonce = 0; // It was signed using 0, it only works (and just once) with 0++ = 1
       const expiry = 1653729994; // 28 may 2022
+      // METAMASK:
       const v = '27';
       const r = '0x4e302ab97d84f720d480d2fce8723158863f30c8557d14989d332966a41c1a5f';
       const s = '0x7e2d62adc8c00d1c84f80fb75b2fcd38a934fad69c3091a5406d67b8c42db57a';
-      await bablToken.delegateBySig(delegatee, nonce, expiry, v, r, s);
+      // LEDGER + METAMASK
+      //const v = '1';
+      //const r = '0x3e9140970233a167713ba23429c8ecc48272a60dd6e422cf6f1cead2bbee87af';
+      //const s = '0x27ca269d6b4e98d3220f62d9f5b99caf75003e7b88d66ab77000a48537fd9b09';
+      // TREZOR
+      //const v = '27';
+      //const r = '0xdbf6a54764d0aa63a21c5ca49aed69195c3531dde0755490817db0764e1a76d4';
+      //const s = '0x4e32366a19416b58cedbb014c4cc67c76294e51f03443f89ae958f7763191512';
+      await bablToken.delegateBySig(delegatee, nonce, expiry, v, r, s, true);
       const walletDelegatee = await impersonateAddress(delegatee);
 
       const [, walletDelegateCheckpointVotes] = await bablToken.getCheckpoints(walletDelegatee.address, 0);


### PR DESCRIPTION
PR to fix 2 issues found during the internal security audit in VoteToken:

1. // R [ISSUE][MEDIUM][HIGH]  Vote delegation by signature was not adding the prefix by signed messages so erecover from ECDSA was not recovering the right address of delegator who signed the message.
(Refs. VoteToken.sol line 123)
2.// R [ISSUE][MEDIUM][HIGH] Vote delegation by signature was stucked as nonce needs to match with the one used in signature before it is increased by ++. StructHash needs to use the same nonce used in the signature process but it was expecting +1 so it might never work.
(Refs. VoteToken.sol line 125)

I added specific tests for it. As it is re-used code, I can understand the second issue while we replaced nonces[signatory]++ inside the require but I cannot understand why other projects like trusttoken or aragon are not using without 

`        bytes32 digestHash = keccak256(abi.encodePacked('\x19Ethereum Signed Message:\n32', digest));
`

[EXPLOIT] We recover a delegator different from 0x00 and different from the real signer which is then blocked by our countermeasure based existing users.
<img width="955" alt="Captura de pantalla 2021-06-02 a las 19 48 48" src="https://user-images.githubusercontent.com/29550529/120528486-d0025500-c3db-11eb-805f-a1612241241e.png">

At the same time, by adding this tests were improved a lot VoteToken.sol and general yarn coverage:

<img width="765" alt="Captura de pantalla 2021-05-29 a las 22 13 54" src="https://user-images.githubusercontent.com/29550529/120083933-89a3b200-c0cc-11eb-9b71-18b54c51aa34.png">
