### PR TITLE
Security fixes  for LendIntegration - nonreentrant and onlySystemContract

### DIFF
--- a/contracts/integrations/lend/LendIntegration.sol
+++ b/contracts/integrations/lend/LendIntegration.sol
@@ -102,7 +102,7 @@ abstract contract LendIntegration is BaseIntegration, ReentrancyGuard, ILendInte
         address _assetToken,
         uint256 _numTokensToSupply,
         uint256 _minAmountExpected
-    ) external override {
+    ) external override nonReentrant onlySystemContract {
         InvestmentInfo memory investmentInfo =
             _createInvestmentInfo(
                 _strategy,
@@ -135,7 +135,7 @@ abstract contract LendIntegration is BaseIntegration, ReentrancyGuard, ILendInte
         address _assetToken,
         uint256 _numTokensToRedeem,
         uint256 _minAmountExpected
-    ) external override {
+    ) external override nonReentrant onlySystemContract {
         InvestmentInfo memory investmentInfo =
             _createInvestmentInfo(
                 _strategy,


### PR DESCRIPTION
PR to add some security best practices to Lend Integration as they are external functions that might be called just by system contracts and with a nonReentrant modifier (like the other integrations) in this case in supplyTokens and RedeemTokens.