### PR TITLE
fix garden script + eslint

### DIFF
--- a/lib/tasks/gardens.js
+++ b/lib/tasks/gardens.js
@@ -31,11 +31,10 @@ task('gardens').setAction(async (args, { getContract, ethers, getRapid }, runSup
     for (const strategy of strategies) {
       const strategyContract = await ethers.getContractAt('Strategy', strategy);
       console.log(`    Strategy ${strategy}`);
+      const [, active, , finalized, executedAt, ,] = await strategyContract.getStrategyState();
 
-      const finalized = await strategyContract.finalized();
       console.log('      finalized', finalized);
 
-      const active = await strategyContract.active();
       console.log('      active', active);
 
       const isExecuting = await strategyContract.isStrategyActive();
@@ -47,7 +46,6 @@ task('gardens').setAction(async (args, { getContract, ethers, getRapid }, runSup
       const enteredCooldownAt = (await strategyContract.enteredCooldownAt()).toNumber();
       console.log('      enteredCooldownAt', enteredCooldownAt);
 
-      const executedAt = (await strategyContract.executedAt()).toNumber();
       console.log('      executedAt', executedAt);
 
       const duration = (await strategyContract.duration()).toNumber();

--- a/test/integrations/CompoundBorrowIntegration.test.js
+++ b/test/integrations/CompoundBorrowIntegration.test.js
@@ -40,7 +40,7 @@ describe('CompoundBorrowIntegrationTest', function () {
       false,
       [asset1Address, 0, asset2Address, 0],
     );
-    let amount = STRATEGY_EXECUTE_MAP[token];
+    const amount = STRATEGY_EXECUTE_MAP[token];
     await executeStrategy(strategyContract, { amount });
     // Check NAV
     expect(await strategyContract.getNAV()).to.be.closeTo(amount, amount.div(50));

--- a/test/token/RewardsDistributor.test.js
+++ b/test/token/RewardsDistributor.test.js
@@ -278,7 +278,7 @@ describe('BABL Rewards Distributor', function () {
       // Mining program has to be enabled before the strategy starts its execution
       await babController.connect(owner).enableBABLMiningProgram();
       const block = await ethers.provider.getBlock();
-      now = block.timestamp;
+      const now = block.timestamp;
 
       const [long1] = await createStrategies([{ garden: garden1 }]);
       await executeStrategy(long1, ONE_ETH);
@@ -309,7 +309,7 @@ describe('BABL Rewards Distributor', function () {
       // Mining program has to be enabled before the strategy starts its execution
       await babController.connect(owner).enableBABLMiningProgram();
       const block = await ethers.provider.getBlock();
-      now = block.timestamp;
+      const now = block.timestamp;
       const strategyContract = await createStrategy(
         'buy',
         'vote',
@@ -341,7 +341,7 @@ describe('BABL Rewards Distributor', function () {
       // Mining program has to be enabled before the strategy starts its execution
       await babController.connect(owner).enableBABLMiningProgram();
       const block = await ethers.provider.getBlock();
-      now = block.timestamp;
+      const now = block.timestamp;
 
       // We try to hack the calculation of rewards taking time from 2 different epochs with a strategy lasting less than 1 epoch in total
       await increaseTime(ONE_DAY_IN_SECONDS * 70);
@@ -370,7 +370,7 @@ describe('BABL Rewards Distributor', function () {
       // Mining program has to be enabled before the strategy starts its execution
       await babController.connect(owner).enableBABLMiningProgram();
       const block = await ethers.provider.getBlock();
-      now = block.timestamp;
+      const now = block.timestamp;
 
       const [long1] = await createStrategies([{ garden: garden1 }]);
 
@@ -396,7 +396,7 @@ describe('BABL Rewards Distributor', function () {
       // Mining program has to be enabled before the strategy starts its execution
       await babController.connect(owner).enableBABLMiningProgram();
       const block = await ethers.provider.getBlock();
-      now = block.timestamp;
+      const now = block.timestamp;
 
       const [long1] = await createStrategies([{ garden: garden1 }]);
       await executeStrategy(long1, ONE_ETH);
@@ -429,7 +429,7 @@ describe('BABL Rewards Distributor', function () {
       // Mining program has to be enabled before the strategy starts its execution
       await babController.connect(owner).enableBABLMiningProgram();
       const block = await ethers.provider.getBlock();
-      now = block.timestamp;
+      const now = block.timestamp;
       const [long1, long2] = await createStrategies([{ garden: garden1 }, { garden: garden1 }]);
 
       await executeStrategy(long1, ONE_ETH);
@@ -472,7 +472,7 @@ describe('BABL Rewards Distributor', function () {
       // Mining program has to be enabled before the strategy starts its execution
       await babController.connect(owner).enableBABLMiningProgram();
       const block = await ethers.provider.getBlock();
-      now = block.timestamp;
+      const now = block.timestamp;
 
       const [long1, long2, long3] = await createStrategies([
         { garden: garden1 },
@@ -526,7 +526,7 @@ describe('BABL Rewards Distributor', function () {
       // Mining program has to be enabled before the strategy starts its execution
       await babController.connect(owner).enableBABLMiningProgram();
       const block = await ethers.provider.getBlock();
-      now = block.timestamp;
+      const now = block.timestamp;
 
       const [long1, long2, long3, long4, long5] = await createStrategies([
         { garden: garden1 },
@@ -616,7 +616,7 @@ describe('BABL Rewards Distributor', function () {
       // Mining program has to be enabled before the strategy starts its execution
       await babController.connect(owner).enableBABLMiningProgram();
       const block = await ethers.provider.getBlock();
-      now = block.timestamp;
+      const now = block.timestamp;
 
       const [long1] = await createStrategies([{ garden: garden1 }]);
 
@@ -637,7 +637,7 @@ describe('BABL Rewards Distributor', function () {
       // Mining program has to be enabled before the strategy starts its execution
       await babController.connect(owner).enableBABLMiningProgram();
       const block = await ethers.provider.getBlock();
-      now = block.timestamp;
+      const now = block.timestamp;
 
       // We go to the future 10 years
       increaseTime(ONE_DAY_IN_SECONDS * 3650);
@@ -668,7 +668,7 @@ describe('BABL Rewards Distributor', function () {
       // Mining program has to be enabled before the strategy starts its execution
       await babController.connect(owner).enableBABLMiningProgram();
       const block = await ethers.provider.getBlock();
-      now = block.timestamp;
+      const now = block.timestamp;
 
       const [long1] = await createStrategies([{ garden: garden1 }]);
 
@@ -699,7 +699,7 @@ describe('BABL Rewards Distributor', function () {
       // Mining program has to be enabled before the strategy starts its execution
       await babController.connect(owner).enableBABLMiningProgram();
       const block = await ethers.provider.getBlock();
-      now = block.timestamp;
+      const now = block.timestamp;
 
       const [long1, long2, long3, long4, long5] = await createStrategies([
         { garden: garden1 },
@@ -788,7 +788,7 @@ describe('BABL Rewards Distributor', function () {
       // Mining program has to be enabled before the strategy starts its execution
       await babController.connect(owner).enableBABLMiningProgram();
       const block = await ethers.provider.getBlock();
-      now = block.timestamp;
+      const now = block.timestamp;
 
       const [long1, long2, long3, long4, long5] = await createStrategies([
         { garden: garden1 },


### PR DESCRIPTION
PR to fix the garden script after the strategy.sol size reduction where .finalized and other variables are now private (so not public available for querying), then we need to use (as BabylonViewer does) getStrategyState.