### PR TITLE
set real deployment vesting date

### DIFF
--- a/deployments/migrations/034-transfer-tokens.js
+++ b/deployments/migrations/034-transfer-tokens.js
@@ -36,7 +36,7 @@ module.exports = async ({ getNamedAccounts, deployments, ethers, getSigner, getC
   ).wait();
 
   console.log('Register investor and team allocations');
-  const investorsVestingStart = new Date();
+  const investorsVestingStart = new Date(2021, 6, 27); // July 27th real token vesting start for investors
   const teamVestingStart = new Date(2021, 2, 15);
   console.log(`Team vestings starts at ${teamVestingStart}`);
   console.log(`Investor vestings starts at ${investorsVestingStart}`);


### PR DESCRIPTION
PR to fix vesting script that was always taking current javascript timestamp for investors but real token was deployed on July the 27th. Due to new security measure (not being able to register  people 30 days ahead of the time), today it started crashing with block number of alchemy.