### PR TITLE
[SECURITY-AUDIT] Fix non used percentage

### DIFF
--- a/contracts/strategies/operations/BorrowOperation.sol
+++ b/contracts/strategies/operations/BorrowOperation.sol
@@ -158,11 +158,14 @@ contract BorrowOperation is Operation {
         uint256 debtAmount = IBorrowIntegration(_integration).getBorrowBalance(msg.sender, assetToken);
         uint256 debtTokenBalance =
             address(0) == assetToken ? address(msg.sender).balance : IERC20(assetToken).balanceOf(address(msg.sender));
-        uint256 maxAmountToRepay = debtAmount > debtTokenBalance ? debtTokenBalance : debtAmount;
+        uint256 amountToRepay =
+            debtAmount > debtTokenBalance
+                ? debtTokenBalance.preciseMul(_percentage)
+                : debtAmount.preciseMul(_percentage);
         IBorrowIntegration(_integration).repay(
             msg.sender,
             assetToken,
-            maxAmountToRepay.preciseMul(_percentage) // We repay the percentage of all that we can
+            amountToRepay // We repay the percentage of all that we can
         );
         return (assetToken, IBorrowIntegration(_integration).getBorrowBalance(msg.sender, assetToken), 2);
     }


### PR DESCRIPTION
PR to fix:

_percentage not used

Description

In the Borrow operation _percentage not used, so we cannot unwind strategy which used borrow operation:
https://github.com/babylon-finance/protocol/blob/d0f1f850404a37b7a8630bf62342ca9b1cfb2ed3/contracts/strategies/operations/BorrowOperation.sol#L161