### PR TITLE
[SECURITY-AUDIT] Calculation of minAmount is incorrect

### DIFF
--- a/contracts/strategies/operations/DepositVaultOperation.sol
+++ b/contracts/strategies/operations/DepositVaultOperation.sol
@@ -154,7 +154,7 @@ contract DepositVaultOperation is Operation {
         uint256 minAmount =
             amountVault.sub(amountVault.preciseMul(SLIPPAGE_ALLOWED)).preciseDiv(
                 IPassiveIntegration(_integration).getPricePerShare(yieldVault).mul(
-                    10**PreciseUnitMath.decimals().sub(ERC20(vaultAsset).decimals())
+                    10**PreciseUnitMath.decimals().sub(vaultAsset == address(0) ? 18 : ERC20(vaultAsset).decimals())
                 )
             );
         IPassiveIntegration(_integration).exitInvestment(msg.sender, yieldVault, amountVault, vaultAsset, minAmount);


### PR DESCRIPTION
In the following function minAmount always would has incorrect decimals because after mul() div() function not called:
https://github.com/babylon-finance/protocol/blob/d0f1f850404a37b7a8630bf62342ca9b1cfb2ed3/contracts/strategies/operations/DepositVaultOperation.sol#L144-L147