### PR TITLE
fix getNAV for vault ops after try/catch returns differently

### DIFF
--- a/contracts/PriceOracle.sol
+++ b/contracts/PriceOracle.sol
@@ -18,6 +18,8 @@
 
 pragma solidity 0.7.6;
 
+import 'hardhat/console.sol';
+
 import {Ownable} from '@openzeppelin/contracts/access/Ownable.sol';
 import {ERC20} from '@openzeppelin/contracts/token/ERC20/ERC20.sol';
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Factory.sol';
@@ -579,6 +581,7 @@ contract PriceOracle is Ownable, IPriceOracle {
             if (yvDecimals < 18) {
                 price = price * 10**(18 - yvDecimals);
             }
+            console.log('VAULT tokenIn', price);
             return price;
         }
 
@@ -586,10 +589,17 @@ contract PriceOracle is Ownable, IPriceOracle {
             price = getPrice(_tokenIn, IYearnVault(_tokenOut).token()).preciseMul(
                 IYearnVault(_tokenOut).pricePerShare()
             );
+            console.log('---token out token---', IYearnVault(_tokenOut).token());
+            console.log('---token out price per share---', IYearnVault(_tokenOut).pricePerShare());
+            console.log('---token getPrice in out token---', getPrice(_tokenIn, IYearnVault(_tokenOut).token()));
+            console.log('---INITIAL PRICE---', price);
+
             uint256 yvDecimals = ERC20(_tokenOut).decimals();
             if (yvDecimals < 18) {
                 price = price * 10**(18 - yvDecimals);
+                console.log('---NORMALIZED PRICE---', price);
             }
+            console.log('VAULT tokenOut price', price);
             return price;
         }
 

--- a/contracts/strategies/operations/DepositVaultOperation.sol
+++ b/contracts/strategies/operations/DepositVaultOperation.sol
@@ -185,6 +185,7 @@ contract DepositVaultOperation is Operation {
         (address vaultAsset, bool assetOrVault) = _getResultAsset(_integration, vault);
         uint256 balance = IERC20(vaultAsset).balanceOf(msg.sender);
         uint256 price = _getPrice(_garden.reserveAsset(), vaultAsset);
+        console.log('price', price);
         // If we cannot price the result asset, we'll use the investment one as a floor
         if (price == 0) {
             vaultAsset = IPassiveIntegration(_integration).getInvestmentAsset(vault);
@@ -198,6 +199,8 @@ contract DepositVaultOperation is Operation {
         //Balance normalization
         balance = SafeDecimalMath.normalizeAmountTokens(vaultAsset, _garden.reserveAsset(), balance);
         uint256 NAV = assetOrVault ? pricePerShare.preciseMul(balance).preciseDiv(price) : balance.preciseMul(price);
+        // uint256 NAV = pricePerShare.preciseMul(balance).preciseDiv(price);
+
         require(NAV != 0, 'NAV has to be bigger 0');
         return (NAV, true);
     }
@@ -205,8 +208,10 @@ contract DepositVaultOperation is Operation {
     // Function to provide backward compatibility
     function _getResultAsset(address _integration, address _yieldVault) private view returns (address, bool) {
         try IPassiveIntegration(_integration).getResultAsset(_yieldVault) returns (address _resultAsset) {
+            console.log('TRY');
             return (_resultAsset, true);
         } catch {
+            console.log('CATCH', _integration);
             return (_yieldVault, false);
         }
     }

--- a/test/upgrades/v0.7.0.test.js
+++ b/test/upgrades/v0.7.0.test.js
@@ -152,38 +152,41 @@ const upgradeFixture = deployments.createFixture(async (hre, options) => {
 describe('v0.7.0', function () {
   let owner;
   let keeper;
+  let priceOracle;
 
   beforeEach(async () => {
-    ({ owner, keeper } = await upgradeFixture());
+    ({ owner, keeper, priceOracle } = await upgradeFixture());
   });
 
   describe('after upgrade', function () {
     describe('can finalizeStrategy', function () {
       for (const [name, strategy] of [
-        ['Leverage long ETH', '0x49567812f97369a05e8D92462d744EFd00d7Ea42'],
-        ['lend eth, borrow dai, harvest dai', '0xcd4fD2a8426c86067836d077eDA7FA2A1dF549dD'],
-        ['Leverage BED', '0x0f4b1585ed506986d3a14436034D1D52704e5b56'],
-        ['Stake ETH - Lido', '0xD8BAdcC27Ecb72F1e88b95172E7DeeeF921883C8'],
+        //    ['Leverage long ETH', '0x49567812f97369a05e8D92462d744EFd00d7Ea42'],
+        //    ['lend eth, borrow dai, harvest dai', '0xcd4fD2a8426c86067836d077eDA7FA2A1dF549dD'],
+        //    ['Leverage BED', '0x0f4b1585ed506986d3a14436034D1D52704e5b56'],
+        //    ['Stake ETH - Lido', '0xD8BAdcC27Ecb72F1e88b95172E7DeeeF921883C8'],
         ['Yearn USDC Vault', '0xa29b722f9D021FE435475b344355521Fa580940F'],
-        ['Lend DAI on Aave', '0x4C449D3C878A6CabaD3f606A4978837Ac5196D5B'],
-        ['Stake ETH', '0x07DEbD22bCa7d010E53fc8ec23E8ADc3a516eC08'],
-        ['end eth, borrow dai, yearn da', '0x27cdbC334cF2dc7Aa720241e9a98Adbc8cc41254'],
-        ['Stable Coin Farm Strategy', '0x40A561a3457F6EFDb8f80cDe3D55D280cce45f3a'],
-        ['ETH-LINK LP', '0xc80C2f1c170fBD793845e67c58e2469569174EA2'],
-        ['WETH-LINK', '0xe3bBF21574E18363733255ba56862E721CD2F3a4'],
-        ['Long BED', '0xE064ad71dc506130A4C1C85Fb137606BaaCDe9c0'],
-        ['Lend weth, borrow dai, farm yearn dai', '0xFDeA6F30F3dadD60382bAA07252923Ff6007c35d'],
-        ['Lend wbtc, borrow dai, yield yearn dai', '0x81b1C6A04599b910e33b1AB549DE4a19E5701838'],
+        //    ['Lend DAI on Aave', '0x4C449D3C878A6CabaD3f606A4978837Ac5196D5B'],
+        //    ['Stake ETH', '0x07DEbD22bCa7d010E53fc8ec23E8ADc3a516eC08'],
+            ['end eth, borrow dai, yearn da', '0x27cdbC334cF2dc7Aa720241e9a98Adbc8cc41254'],
+        //    ['Stable Coin Farm Strategy', '0x40A561a3457F6EFDb8f80cDe3D55D280cce45f3a'],
+        //    ['ETH-LINK LP', '0xc80C2f1c170fBD793845e67c58e2469569174EA2'],
+        //    ['WETH-LINK', '0xe3bBF21574E18363733255ba56862E721CD2F3a4'],
+        //    ['Long BED', '0xE064ad71dc506130A4C1C85Fb137606BaaCDe9c0'],
+        //    ['Lend weth, borrow dai, farm yearn dai', '0xFDeA6F30F3dadD60382bAA07252923Ff6007c35d'],
+        //    ['Lend wbtc, borrow dai, yield yearn dai', '0x81b1C6A04599b910e33b1AB549DE4a19E5701838'],
         ['Yearn - DAI Vault', '0x23E6E7B35E9E117176799cEF885B9D4a97D42df9'],
-        ['ETHficient Stables', '0x3d4c6303E8E6ad9F4697a5c3deAe9827217439Ae'],
-        ['long DAI', '0xB0147911b9d584618eB8F3BF63AD1AB858085101'],
-        ['RAI/ETH UNI LP', '0x884957Fd342993A748c82aC608043859F1482126'],
+        //    ['ETHficient Stables', '0x3d4c6303E8E6ad9F4697a5c3deAe9827217439Ae'],
+        //    ['long DAI', '0xB0147911b9d584618eB8F3BF63AD1AB858085101'],
+        //   ['RAI/ETH UNI LP', '0x884957Fd342993A748c82aC608043859F1482126'],
       ]) {
         it(name, async () => {
           const strategyContract = await ethers.getContractAt('IStrategy', strategy, owner);
 
           await increaseTime(ONE_DAY_IN_SECONDS * 360);
-
+          console.log('NAV', (await strategyContract.getNAV()).toString());
+          console.log('CAPITAL ALLOCATED', (await strategyContract.capitalAllocated()).toString());
+          //console.log('GETPRICE', await priceOracle.getPrice( '0x6B175474E89094C44Da98b954EedeAC495271d0F', '0x19D3364A399d251E894aC732651be8B0E4e85001'));
           await strategyContract.connect(keeper).finalizeStrategy(0, '');
           const [, active, , finalized, , exitedAt] = await strategyContract.getStrategyState();
 


### PR DESCRIPTION
PR to fix getNAV after new upgrade due to sometimes we get the address of the assetVault or just the vaultAddress so we need to use the directPrice (reserveAsset to vault directly) returned by PriceOracle or the pricePerShare + price to go from reserveAsset to assetVault and then from assetVault to vault.