### PR TITLE
fix some babl calculations

### DIFF
--- a/contracts/token/RewardsDistributor.sol
+++ b/contracts/token/RewardsDistributor.sol
@@ -784,21 +784,20 @@ contract RewardsDistributor is OwnableUpgradeable, IRewardsDistributor {
         uint256 strategyRewards = strategy.strategyRewards();
         int256 userVotes = strategy.getUserVotes(_contributor);
         uint256 allocated = strategy.capitalAllocated();
-        uint256 totalPositiveVotes = strategy.totalPositiveVotes();
+        uint256 totalVotes = strategy.totalPositiveVotes().add(strategy.totalNegativeVotes());
         uint256 bablCap;
         uint256 expected = allocated.add(allocated.preciseMul(strategy.expectedReturn()));
-
         // Get proportional voter (stewards) rewards in case the contributor was also a steward of the strategy
         uint256 babl;
         if (userVotes > 0 && _profit == true && _distance == true) {
             // Voting in favor of the execution of the strategy with profits and positive distance
             babl = strategyRewards.multiplyDecimal(BABL_STEWARD_SHARE).preciseMul(
-                uint256(userVotes).preciseDiv(totalPositiveVotes)
+                uint256(userVotes).preciseDiv(totalVotes)
             );
         } else if (userVotes > 0 && _profit == true && _distance == false) {
             // Voting in favor positive profits but below expected return
             babl = strategyRewards.multiplyDecimal(BABL_STEWARD_SHARE).preciseMul(
-                uint256(userVotes).preciseDiv(totalPositiveVotes)
+                uint256(userVotes).preciseDiv(totalVotes)
             );
             // We discount the error of expected return vs real returns
             babl = babl.sub(babl.preciseMul(_distanceValue.preciseDiv(expected)));
@@ -809,7 +808,7 @@ contract RewardsDistributor is OwnableUpgradeable, IRewardsDistributor {
             // Voting against a strategy that got results below expected return provides rewards
             // to the voter (helping the protocol to only have good strategies)
             babl = strategyRewards.multiplyDecimal(BABL_STEWARD_SHARE).preciseMul(
-                uint256(Math.abs(userVotes)).preciseDiv(strategy.totalNegativeVotes())
+                uint256(Math.abs(userVotes)).preciseDiv(totalVotes)
             );
 
             bablCap = babl.mul(2); // Max cap
@@ -842,18 +841,16 @@ contract RewardsDistributor is OwnableUpgradeable, IRewardsDistributor {
         IStrategy strategy = IStrategy(_strategy);
         // Get proportional voter (stewards) rewards in case the contributor was also a steward of the strategy
         int256 userVotes = strategy.getUserVotes(_contributor);
+        uint256 totalVotes = strategy.totalPositiveVotes().add(strategy.totalNegativeVotes());
         uint256 profitShare =
             gardenCustomProfitSharing[_garden] ? gardenProfitSharing[_garden][1] : PROFIT_STEWARD_SHARE;
         if (_profit == true) {
             if (userVotes > 0) {
-                return
-                    _profitValue.multiplyDecimal(profitShare).preciseMul(uint256(userVotes)).preciseDiv(
-                        strategy.totalPositiveVotes()
-                    );
+                return _profitValue.multiplyDecimal(profitShare).preciseMul(uint256(userVotes)).preciseDiv(totalVotes);
             } else if ((userVotes < 0) && _distance == false) {
                 return
                     _profitValue.multiplyDecimal(profitShare).preciseMul(uint256(Math.abs(userVotes))).preciseDiv(
-                        strategy.totalNegativeVotes()
+                        totalVotes
                     );
             } else if ((userVotes < 0) && _distance == true) {
                 // Voted against a very profit strategy above expected returns, get no profit at all
@@ -948,14 +945,12 @@ contract RewardsDistributor is OwnableUpgradeable, IRewardsDistributor {
         IStrategy strategy = IStrategy(_strategy);
         uint256 strategyRewards = strategy.strategyRewards();
         uint256 babl;
-        uint256 allocated =
-            SafeDecimalMath.normalizeAmountTokens(IGarden(_garden).reserveAsset(), DAI, strategy.capitalAllocated());
         uint256[] memory ts = new uint256[](3);
         // ts[0]: executedAt, ts[1]: exitedAt, ts[2]: updatedAt
         (, , , , ts[0], ts[1], ts[2]) = strategy.getStrategyState();
         uint256 contributorPower = _getContributorPower(_garden, _contributor, ts[0], ts[1]);
         // We take care of normalization into 18 decimals for capital allocated in less decimals than 18
-        babl = strategyRewards.multiplyDecimal(BABL_LP_SHARE).preciseMul(contributorPower.preciseDiv(allocated));
+        babl = strategyRewards.multiplyDecimal(BABL_LP_SHARE).preciseMul(contributorPower);
         return babl;
     }
 


### PR DESCRIPTION
PR to fix 2 calculations:

1. Stewards: that was considering positive or negative votes as denominator of user votes instead of the total amount. It might produce an incorrect distribution of rewards. It is related to MoB vuln reported.

2. Removal of capital allocation division of LP BABL rewards, it has to be only `strategyRewards x LP % x contributor Power `(which is actually a % in 18 decimals as well). No need to divide by capital allocated.