### PR TITLE
[SECURITY-AUDIT-FIX]  Impossible finalization of the strategy

### DIFF
--- a/contracts/lib/BabylonErrors.sol
+++ b/contracts/lib/BabylonErrors.sol
@@ -286,4 +286,6 @@ library Errors {
     uint256 internal constant NO_PRICE_FOR_TRADE = 98;
     // Max capital requested
     uint256 internal constant ZERO_CAPITAL_REQUESTED = 99;
+    // Unwind capital above the limit
+    uint256 internal constant INVALID_CAPITAL_TO_UNWIND = 100;
 }

--- a/contracts/strategies/Strategy.sol
+++ b/contracts/strategies/Strategy.sol
@@ -413,7 +413,8 @@ contract Strategy is ReentrancyGuard, IStrategy, Initializable {
         );
         _onlyUnpaused();
         _require(active && !finalized, Errors.STRATEGY_NEEDS_TO_BE_ACTIVE);
-
+        // An unwind should not allow users to remove all capital from a strategy
+        _require(_amountToUnwind < capitalAllocated, Errors.INVALID_CAPITAL_TO_UNWIND);
         // Exits and enters the strategy
         _exitStrategy(_amountToUnwind.preciseDiv(capitalAllocated));
         capitalAllocated = capitalAllocated.sub(_amountToUnwind);


### PR DESCRIPTION
If somehow contributors unwind 100% of strategy assets, then this strategy cannot be finalized, which means that users cannot get any rewards:

https://github.com/babylon-finance/protocol/blob/d0f1f850404a37b7a8630bf62342ca9b1cfb2ed3/contracts/strategies/Strategy.sol#L441