### PR TITLE
[SECURITY-AUDIT-FIX] Unequal length of arrays

### DIFF
--- a/contracts/lib/BabylonErrors.sol
+++ b/contracts/lib/BabylonErrors.sol
@@ -294,4 +294,6 @@ library Errors {
     uint256 internal constant MAX_TRADE_SLIPPAGE_PERCENTAGE = 102;
     // Max gas fee percentage
     uint256 internal constant MAX_GAS_FEE_PERCENTAGE = 103;
+    // Mismatch between voters and votes
+    uint256 internal constant INVALID_VOTES_LENGTH = 104;
 }

--- a/contracts/strategies/Strategy.sol
+++ b/contracts/strategies/Strategy.sol
@@ -328,7 +328,7 @@ contract Strategy is ReentrancyGuard, IStrategy, Initializable {
         _require(_voters.length >= garden.minVoters(), Errors.MIN_VOTERS_CHECK);
         _require(!active && !finalized, Errors.VOTES_ALREADY_RESOLVED);
         _require(block.timestamp.sub(enteredAt) <= MAX_CANDIDATE_PERIOD, Errors.VOTING_WINDOW_IS_OVER);
-
+        _require(_voters.length == _votes.length, Errors.INVALID_VOTES_LENGTH);
         active = true;
 
         // set votes to zero expecting keeper to provide correct values


### PR DESCRIPTION
PR to fix mob medium 25:

In the following function the length of input data can be unequal _voters.length != _votes.length:
https://github.com/babylon-finance/protocol/blob/d0f1f850404a37b7a8630bf62342ca9b1cfb2ed3/contracts/strategies/Strategy.sol#L362

Recommendation
We recommend to add the following check:

require(_voters.length == _votes.length, 'Incorrect input');