### PR TITLE
[GARDEN > 24KB] [SECURITY-AUDIT-FIX] Possible reentrancy between 2 strategies from 1 garden

### DIFF
--- a/contracts/gardens/Garden.sol
+++ b/contracts/gardens/Garden.sol
@@ -568,7 +568,7 @@ contract Garden is ERC20Upgradeable, ReentrancyGuard, IGarden {
      * @param _keeper  Keeper that executed the transaction
      * @param _fee     The fee paid to keeper to compensate the gas cost
      */
-    function payKeeper(address payable _keeper, uint256 _fee) public override {
+    function payKeeper(address payable _keeper, uint256 _fee) public override nonReentrant {
         _onlyUnpaused();
         _require(msg.sender == address(this) || strategyMapping[msg.sender], Errors.ONLY_STRATEGY);
         _require(IBabController(controller).isValidKeeper(_keeper), Errors.ONLY_KEEPER);
@@ -662,7 +662,7 @@ contract Garden is ERC20Upgradeable, ReentrancyGuard, IGarden {
      *
      * @param _capital        Amount of capital to allocate to the strategy
      */
-    function allocateCapitalToStrategy(uint256 _capital) external override {
+    function allocateCapitalToStrategy(uint256 _capital) external override nonReentrant {
         _onlyStrategy();
 
         uint256 protocolMgmtFee = IBabController(controller).protocolManagementFee().preciseMul(_capital);


### PR DESCRIPTION
Multistrategy reentrancy possible because nonReentrant modificator works only inside 1 strategy:
https://github.com/babylon-finance/protocol/blob/d0f1f850404a37b7a8630bf62342ca9b1cfb2ed3/contracts/strategies/Strategy.sol#L386

Recommendation
We recommend to add a flag for garden to check multistrategy reentrancy.

Need contract size reduction below 24kb:

<img width="349" alt="Captura de pantalla 2021-10-24 a las 21 01 57" src="https://user-images.githubusercontent.com/29550529/138608805-3c8c43fc-5de7-4050-8a98-2b821475f247.png">


