### PR TITLE
[SECURITY-AUDIT-FIX] Unchecked vault address

### DIFF
--- a/contracts/strategies/operations/DepositVaultOperation.sol
+++ b/contracts/strategies/operations/DepositVaultOperation.sol
@@ -70,7 +70,9 @@ contract DepositVaultOperation is Operation {
         IGarden, /* _garden */
         address _integration,
         uint256 /* _index */
-    ) external view override onlyStrategy {}
+    ) external view override onlyStrategy {
+        require(BytesLib.decodeOpDataAddress(_data) != address(0), 'Incorrect vault address!');
+    }
 
     /**
      * Executes the deposit vault operation


### PR DESCRIPTION
In the following function _data contains address of yieldVault and it is can be zero address:
https://github.com/babylon-finance/protocol/blob/d0f1f850404a37b7a8630bf62342ca9b1cfb2ed3/contracts/strategies/operations/DepositVaultOperation.sol#L65

Recommendation
We recommend to add a check like this:

require(BytesLib.decodeOpDataAddress(_data) != address(0), 'Incorrect vault address!');