### PR TITLE
[SECURITY-AUDIT-FIX] Modificator not used

### DIFF
--- a/contracts/strategies/operations/BorrowOperation.sol
+++ b/contracts/strategies/operations/BorrowOperation.sol
@@ -23,6 +23,7 @@ import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import {IGarden} from '../../interfaces/IGarden.sol';
 import {IStrategy} from '../../interfaces/IStrategy.sol';
 import {IBorrowIntegration} from '../../interfaces/IBorrowIntegration.sol';
+import {IBabController} from '../../interfaces/IBabController.sol';
 
 import {PreciseUnitMath} from '../../lib/PreciseUnitMath.sol';
 import {SafeDecimalMath} from '../../lib/SafeDecimalMath.sol';
@@ -182,8 +183,7 @@ contract BorrowOperation is Operation {
         bytes calldata _data,
         IGarden _garden,
         address _integration
-    ) external view override returns (uint256, bool) {
-        require(_garden.isGardenStrategy(msg.sender), 'garden strategy mismatch');
+    ) external view override onlyStrategy returns (uint256, bool) {
         address borrowToken = BytesLib.decodeOpDataAddress(_data); // 64 bytes (w/o signature prefix bytes4)
         if (!IStrategy(msg.sender).isStrategyActive()) {
             return (0, true);


### PR DESCRIPTION
Function getNAV() can be called by any smart contract which has isStrategyActive public bool variable:
https://github.com/babylon-finance/protocol/blob/d0f1f850404a37b7a8630bf62342ca9b1cfb2ed3/contracts/strategies/operations/BorrowOperation.sol#L179

Recommendation
We recommend to add onlyStrategy modifier.

