### PR TITLE
[SECURITY-AUDIT-FIX] Incorrect sender check

### DIFF
--- a/contracts/gardens/Garden.sol
+++ b/contracts/gardens/Garden.sol
@@ -991,7 +991,7 @@ contract Garden is ERC20Upgradeable, ReentrancyGuard, IGarden {
     ) private {
         _onlyUnpaused();
         (bool canDeposit, , ) = _getUserPermission(_from);
-        _require(canDeposit || _isCreator(_to), Errors.USER_CANNOT_JOIN);
+        _require(_isCreator(_to) || (canDeposit && _from == _to), Errors.USER_CANNOT_JOIN);
 
         if (maxDepositLimit > 0) {
             // This is wrong; but calculate principal would be gas expensive


### PR DESCRIPTION
In case msg.sender != _to and msg.sender can join garden, sender can create deposit for user, which doesn’t have these rights:
https://github.com/babylon-finance/protocol/blob/d0f1f850404a37b7a8630bf62342ca9b1cfb2ed3/contracts/gardens/Garden.sol#L332

Recommendation
We recommend to check that _to also has rights for joining garden.

