### PR TITLE
[SECURITY-AUDIT-FIX] Incorrect withdrawal quantity

### DIFF
--- a/contracts/gardens/Garden.sol
+++ b/contracts/gardens/Garden.sol
@@ -911,7 +911,7 @@ contract Garden is ERC20Upgradeable, ReentrancyGuard, IGarden {
             IStrategy(_unwindStrategy).unwindStrategy(amountOut.add(amountOut.preciseMul(5e16)), _strategyNAV);
         }
 
-        _require(amountOut >= _minAmountOut, Errors.RECEIVE_MIN_AMOUNT);
+        _require(amountOut >= _minAmountOut && _amountIn > 0, Errors.RECEIVE_MIN_AMOUNT);
 
         _require(liquidReserve() >= amountOut, Errors.MIN_LIQUIDITY);
         // We need previous supply before minting new tokens to get accurate rewards calculations


### PR DESCRIPTION
In the following function it is possible to _gardenTokenQuantity == 0:
https://github.com/babylon-finance/protocol/blob/d0f1f850404a37b7a8630bf62342ca9b1cfb2ed3/contracts/gardens/Garden.sol#L401

Recommendation
We recommend to add a check like this:

require(_gardenTokenQuantity > minGardenTokenQuantity, 'Insufficient amount to withdraw');