### PR TITLE
[NEED FIX TESTS] [SECURITY-AUDIT-FIX] Liquid reserves not used

### DIFF
--- a/contracts/gardens/Garden.sol
+++ b/contracts/gardens/Garden.sol
@@ -902,7 +902,7 @@ contract Garden is ERC20Upgradeable, ReentrancyGuard, IGarden {
         uint256 amountOut = amountOutNormalized.preciseMul(10**ERC20Upgradeable(reserveAsset).decimals());
 
         // if withPenaltiy then unwind strategy
-        if (_withPenalty) {
+        if (_withPenalty && !(liquidReserve() >= amountOut)) {
             amountOut = amountOut.sub(amountOut.preciseMul(EARLY_WITHDRAWAL_PENALTY));
             // When unwinding a strategy, a slippage on integrations will result in receiving less tokens
             // than desired so we have have to account for this with a 5% slippage.


### PR DESCRIPTION
Liquid reserves of garden is not checked if user tries unwind strategy:
https://github.com/babylon-finance/protocol/blob/d0f1f850404a37b7a8630bf62342ca9b1cfb2ed3/contracts/gardens/Garden.sol#L410

Recommendation
We recommend to add a check of liquid reserves and if reserves amount is enough to pay user then do not unwind strategy.