### PR TITLE
[STRATEGY-REWARDS] Add rewards data to strategy for deterministic rewards

### DIFF
--- a/contracts/strategies/Strategy.sol
+++ b/contracts/strategies/Strategy.sol
@@ -203,7 +203,7 @@ contract Strategy is ReentrancyGuard, IStrategy, Initializable {
     uint256[] private tokenAmountsNeeded; // Not used anymore
 
     uint256 public override strategyRewards; // Rewards allocated for this strategy updated on finalized
-    uint256 private endingGardenSupply; // garden token supply when strategy starts
+    uint256 private endingGardenSupply; // garden token supply when strategy ends
 
     // Voters mapped to their votes.
     mapping(address => int256) private votes;


### PR DESCRIPTION
PR to add some relevant information to be used for strategy rewards in order to guarantee deterministic BABL calculations.

<img width="307" alt="Captura de pantalla 2021-10-26 a las 20 24 14" src="https://user-images.githubusercontent.com/29550529/138938489-e5091cf1-c301-43bd-ab51-8cf8ff3c4089.png">
.