### PR TITLE
Garden delegation feature

### DIFF
--- a/contracts/gardens/AdminGardenModule.sol
+++ b/contracts/gardens/AdminGardenModule.sol
@@ -266,7 +266,7 @@ contract AdminGardenModule is BaseGardenModule, IAdminGarden {
      * @param _token         Address of BABL or any other ERC20Comp related governance token
      * @param _delegatee     Address to delegate token voting power into
      */
-    function delegateGardenVote(address _token, address _delegatee) external override {
+    function delegateVotes(address _token, address _delegatee) external override {
         _onlyCreator(msg.sender);
         _require(_token != address(0) && _delegatee != address(0), Errors.ADDRESS_IS_ZERO);
         IVoteToken(_token).delegate(_delegatee);

--- a/contracts/interfaces/IGarden.sol
+++ b/contracts/interfaces/IGarden.sol
@@ -77,7 +77,7 @@ interface IAdminGarden {
 
     function setPublicRights(bool _publicStrategist, bool _publicStewards) external;
 
-    function delegateGardenVote(address _token, address _address) external;
+    function delegateVotes(address _token, address _address) external;
 
     function updateCreators(address _newCreator, address[4] memory _newCreators) external;
 

--- a/test/unit/gardens/Garden.test.js
+++ b/test/unit/gardens/Garden.test.js
@@ -215,7 +215,7 @@ describe('Garden', function () {
       const heartDelegatee1 = await token.delegates(heartGarden.address);
       expect(heartDelegatee1).to.eq(ADDRESS_ZERO); // No delegation yet
       const creator = await impersonateAddress(await heartGarden.creator());
-      await heartGarden.connect(creator).delegateGardenVote(token.address, heart.address);
+      await heartGarden.connect(creator).delegateVotes(token.address, heart.address);
       const heartDelegatee2 = await token.delegates(heartGarden.address);
       expect(heartDelegatee2).to.eq(heart.address);
     });


### PR DESCRIPTION
PR to allow a garden to delegate erc20 votes (bravo compatible) to an address. 

We will be using it to delegate into heart by heart garden for BABL but it might work for other bravo compatible tokens and addresses if needed.