### PR TITLE
Add hardlockStartsAt to viewer

### DIFF
--- a/contracts/interfaces/IViewer.sol
+++ b/contracts/interfaces/IViewer.sol
@@ -58,7 +58,7 @@ interface IGardenViewer {
             bool[4] memory actors,
             address[] memory strategies,
             address[] memory finalizedStrategies,
-            uint256[15] memory params,
+            uint256[16] memory params,
             uint256[10] memory stats,
             uint256[3] memory profits
         );

--- a/contracts/viewer/GardenViewer.sol
+++ b/contracts/viewer/GardenViewer.sol
@@ -100,7 +100,7 @@ contract GardenViewer is IGardenViewer {
             bool[4] memory actors,
             address[] memory strategies,
             address[] memory finalizedStrategies,
-            uint256[15] memory params,
+            uint256[16] memory params,
             uint256[10] memory stats,
             uint256[3] memory profits
         )
@@ -153,7 +153,8 @@ contract GardenViewer is IGardenViewer {
                 garden.pricePerShareDelta(),
                 garden.verifiedCategory(),
                 garden.canMintNftAfter(),
-                garden.customIntegrationsEnabled() ? 1 : 0
+                garden.customIntegrationsEnabled() ? 1 : 0,
+                garden.hardlockStartsAt()
             ],
             [
                 principal,


### PR DESCRIPTION
PR to allow accurate calculations of heart garden withdrawals epochs based on hardlockStartsAt variable.