### PR TITLE
Governor token transfer allowed after vote

### DIFF
--- a/test/integration/token/governance/BabylonGovernor.test.js
+++ b/test/integration/token/governance/BabylonGovernor.test.js
@@ -334,7 +334,7 @@ describe('BabylonGovernor', function () {
       // Check all voters have voted
       expect(await mockGovernor.hasVoted(id, voter1.address)).to.be.equal(true);
       expect(await mockGovernor.hasVoted(id, voter3.address)).to.be.equal(true);
-      // Check voting results are the same despite the token was
+      // Check voting results are the same despite the tokens were transferred after voting
       expect(forVotes).to.eq(forVotes2);
       expect(againstVotes).to.eq(againstVotes2);
       expect(abstainVotes).to.eq(abstainVotes2);


### PR DESCRIPTION
Test to check that token transfers after voting does not affect a governance vote.

Note: I also tested TRIBE DAO Governor behavior and it is the same. I decided not to include that external test in our PR. 

Here a screenshot:
<img width="701" alt="Captura de Pantalla 2022-06-08 a las 16 10 25" src="https://user-images.githubusercontent.com/29550529/172640751-0ad5c030-6674-4e81-a785-210085def8d6.png">


<img width="623" alt="Captura de Pantalla 2022-06-08 a las 16 23 14" src="https://user-images.githubusercontent.com/29550529/172641194-756117ef-9ad1-4846-82a1-6df31f5f83e3.png">

