### PR TITLE
Avoid un-initialized implementations

### DIFF
--- a/contracts/BabController.sol
+++ b/contracts/BabController.sol
@@ -183,6 +183,7 @@ contract BabController is OwnableUpgradeable, IBabController {
     uint8 public constant MAX_OPERATIONS = 20;
 
     /* ============ Constructor ============ */
+    constructor() initializer {}
 
     /**
      * Initializes the initial fee recipient on deployment.

--- a/contracts/mocks/RewardsDistributorV2Mock.sol
+++ b/contracts/mocks/RewardsDistributorV2Mock.sol
@@ -218,6 +218,8 @@ contract RewardsDistributorV2Mock is OwnableUpgradeable {
 
     /* ============ Constructor ============ */
 
+    constructor() initializer {}
+
     function initialize(TimeLockedToken _bablToken, IBabController _controller) public {
         OwnableUpgradeable.__Ownable_init();
         _require(address(_bablToken) != address(0) && address(_controller) != address(0), Errors.ADDRESS_IS_ZERO);

--- a/contracts/token/RewardsDistributor.sol
+++ b/contracts/token/RewardsDistributor.sol
@@ -293,6 +293,8 @@ contract RewardsDistributor is OwnableUpgradeable, IRewardsDistributor {
 
     /* ============ Constructor ============ */
 
+    constructor() initializer {}
+
     function initialize(TimeLockedToken _bablToken, IBabController _controller) public initializer {
         OwnableUpgradeable.__Ownable_init();
         _require(address(_bablToken) != address(0) && address(_controller) != address(0), Errors.ADDRESS_IS_ZERO);


### PR DESCRIPTION
Previously reported as internal bug to Immunefi. Checked as well with Igor. Tx's to initialize them executed.